### PR TITLE
Pequeña actualización

### DIFF
--- a/src/r_config.cpp
+++ b/src/r_config.cpp
@@ -85,7 +85,7 @@ INT_PTR CALLBACK VentanaConfiguracion(HWND hwndConf, UINT mensaje, WPARAM wParam
 	{
 		case WM_INITDIALOG:
 			// Cargamos la configuración y la mostramos en el dialogo
-			SetWindowText(GetDlgItem(hwndConf, ID_CONF_INDICATIVO), _T("Ej: TANGO-1"));
+			SetWindowText(GetDlgItem(hwndConf, ID_CONF_INDICATIVO), _T("Ej: ADAM-15"));
 			if(wcscmp(radioInteligente.obtenerNombreIndicativo(), _T("N/A")))
 				SetWindowText(GetDlgItem(hwndConf, ID_CONF_INDICATIVO), radioInteligente.obtenerNombreIndicativo());
 			CheckDlgButton(hwndConf, ID_A_REUNION, radioInteligente.obtenerValorAviso(A_REUNION_GENERAL));
@@ -126,7 +126,7 @@ INT_PTR CALLBACK VentanaConfiguracion(HWND hwndConf, UINT mensaje, WPARAM wParam
 						MessageBeep(MB_ICONERROR);
 						MessageBox(hwndConf, _T("El campo del indicativo de la unidad está vacío o tiene un formato incorrecto.")
 							_T(" Recuerde que el campo debe contener el indicativo completo de la unidad.\n\n")
-							_T("Ejemplo: TANGO-1."),
+							_T("Ejemplo: ADAM-15."),
 							_T("Error"), MB_OK | MB_ICONEXCLAMATION);
 						break;
 					}

--- a/src/r_config.cpp
+++ b/src/r_config.cpp
@@ -85,7 +85,7 @@ INT_PTR CALLBACK VentanaConfiguracion(HWND hwndConf, UINT mensaje, WPARAM wParam
 	{
 		case WM_INITDIALOG:
 			// Cargamos la configuración y la mostramos en el dialogo
-			SetWindowText(GetDlgItem(hwndConf, ID_CONF_INDICATIVO), _T("Ej: ADAM-1"));
+			SetWindowText(GetDlgItem(hwndConf, ID_CONF_INDICATIVO), _T("Ej: TANGO-1"));
 			if(wcscmp(radioInteligente.obtenerNombreIndicativo(), _T("N/A")))
 				SetWindowText(GetDlgItem(hwndConf, ID_CONF_INDICATIVO), radioInteligente.obtenerNombreIndicativo());
 			CheckDlgButton(hwndConf, ID_A_REUNION, radioInteligente.obtenerValorAviso(A_REUNION_GENERAL));
@@ -126,7 +126,7 @@ INT_PTR CALLBACK VentanaConfiguracion(HWND hwndConf, UINT mensaje, WPARAM wParam
 						MessageBeep(MB_ICONERROR);
 						MessageBox(hwndConf, _T("El campo del indicativo de la unidad está vacío o tiene un formato incorrecto.")
 							_T(" Recuerde que el campo debe contener el indicativo completo de la unidad.\n\n")
-							_T("Ejemplo: ADAM-1."),
+							_T("Ejemplo: TANGO-1."),
 							_T("Error"), MB_OK | MB_ICONEXCLAMATION);
 						break;
 					}

--- a/src/r_main.cpp
+++ b/src/r_main.cpp
@@ -707,11 +707,6 @@ void analizarMensajes() {
 
 	if (strstr(mensajeCompleto, "**[id: ") != NULL || strstr(mensajeCompleto, "**[rj ") != NULL || strstr(mensajeCompleto, ", c: ") != NULL || strstr(mensajeCompleto, "[radio id: ") != NULL || strstr(mensajeCompleto, "| ch: ") != NULL)
 	{
-		if (strstr(mensajeCompleto, "**[rj ") != NULL)
-		{
-			reproducirSonido(archivosDeSonido[S_IMPORTANTE]);
-			return;
-		}
 		// Avisos de reunión general (10-80)
 		if(radioInteligente.obtenerValorAviso(A_REUNION_GENERAL))
 		{
@@ -738,13 +733,6 @@ void analizarMensajes() {
 				reproducirSonido(archivosDeSonido[S_IMPORTANTE]);
 				return;
 			}
-		}
-		// Avisos de código cuatro
-		if (strstr(mensajeCompleto, "codigo cuatro") != NULL || strstr(mensajeCompleto, "codigo 4") != NULL)
-		{
-			Sleep(250);
-			reproducirSonido(archivosDeSonido[S_CODIGO_CUATRO]);
-			return;
 		}
 		// Avisos roleados de centralita
 		if(radioInteligente.obtenerValorAviso(A_CENTRALITA))
@@ -822,7 +810,8 @@ void analizarMensajes() {
 		{
 			if(contieneMensajePalabras(mensajeCompleto, PC_PEDIDOS_SWAT))
 			{
-				/* Notificamos a las posibles unidades metro activas. */
+				/* Sólo enviamos esta notificación a oficiales patrullando en unidades
+				   SWAT y a las unidades supervisoras */
 
 				if(wcsstr(radioInteligente.obtenerNombreIndicativo(), L"DAVID") != NULL ||
 					wcsstr(radioInteligente.obtenerNombreIndicativo(), L"LINCOLN") != NULL ||
@@ -885,7 +874,7 @@ void analizarMensajes() {
 				}
 				if(strstr(mensajeCompleto, "custodia") != NULL || strstr(mensajeCompleto, "bajo custodia") != NULL || strstr(mensajeCompleto, "en custodia") != NULL)
 				{
-					Sleep(250);
+					Sleep(1000);
 					reproducirSonido(archivosDeSonido[sonidoAleatorio]);
 					return;
 				}
@@ -899,7 +888,7 @@ void analizarMensajes() {
 				}
 				if(strstr(mensajeCompleto, "custodia") != NULL || strstr(mensajeCompleto, "bajo custodia") != NULL || strstr(mensajeCompleto, "en custodia") != NULL)
 				{
-					Sleep(250);
+					Sleep(1000);
 					reproducirSonido(archivosDeSonido[S_CUSTODIA]);
 					return;
 				}
@@ -1024,7 +1013,7 @@ void analizarMensajes() {
 	// Avisos de robo al banco
 	if(radioInteligente.obtenerValorAviso(A_ROBO_BANCO))
 	{
-		if(strstr(mensajeCompleto, "[centralita]") != NULL && strstr(mensajeCompleto, "banco de temple") != NULL)
+		if(strstr(mensajeCompleto, "[centralita]") != NULL && strstr(mensajeCompleto, "banco de rodeo") != NULL)
 		{
 			reproducirSonido(archivosDeSonido[S_ROBO_BANCO]);
 			return;

--- a/src/r_main.cpp
+++ b/src/r_main.cpp
@@ -707,6 +707,11 @@ void analizarMensajes() {
 
 	if (strstr(mensajeCompleto, "**[id: ") != NULL || strstr(mensajeCompleto, "**[rj ") != NULL || strstr(mensajeCompleto, ", c: ") != NULL || strstr(mensajeCompleto, "[radio id: ") != NULL || strstr(mensajeCompleto, "| ch: ") != NULL)
 	{
+		if (strstr(mensajeCompleto, "**[rj ") != NULL)
+		{
+			reproducirSonido(archivosDeSonido[S_IMPORTANTE]);
+			Sleep(300);
+		}
 		// Avisos de reunión general (10-80)
 		if(radioInteligente.obtenerValorAviso(A_REUNION_GENERAL))
 		{

--- a/src/r_radio.cpp
+++ b/src/r_radio.cpp
@@ -119,8 +119,8 @@ const char *PC_PROHIBIDAS_GENERAL[] = {
 
 const char *PC_REUNION_GENERAL[] = {
 
-	"1080 general", "'80 general", "80' general",
-	"sala de asignaciones", "10-80 general", "80 general",
+	"1080 general en", "'80 general en", "80' general en",
+	"sala de asignaciones", "10-80 general en", "80 general en",
 
 	NULL
 };
@@ -146,7 +146,7 @@ const char *PC_CENTRALITA[] = {
 	"[central]", "[centralita]", "[despacho]",
 	"[dispatch]", "central:", "-central-",
 	"-despacho-", "despacho:", "-centralita-",
-	"-dispatch-", "dispatch",
+	"-dispatch-", "[dispatch]",
 
 	NULL
 };

--- a/src/r_radio.cpp
+++ b/src/r_radio.cpp
@@ -73,8 +73,7 @@ const wchar_t *archivosDeSonido[] = {
     L"robo1.wav", // S_ROBO_UNO
     L"robo2.wav", // S_ROBO_DOS
     L"robo3.wav", // S_ROBO_TRES
-    L"robo4.wav", // S_ROBO_CUATRO
-	L"codigo4.wav" //S_CODIGO_CUATRO
+    L"robo4.wav" // S_ROBO_CUATRO
 };
 
 // Entradas de configuración para los avisos, enlazados con el enumerador
@@ -156,8 +155,7 @@ const char *PC_REP_UNIDADES[] = {
 
 	"reporten", "asignaciones", "componen",
 	"miembros", "reportense", "reportar",
-	"unidades activas", "actuales", "codigo 6 charles",
-	"6-charles", "seis charles", "6 charles", "86 forzoso",
+	"unidades activas", "actuales",
 
 	NULL
 };

--- a/src/r_radio.h
+++ b/src/r_radio.h
@@ -80,7 +80,6 @@ typedef enum {
     S_ROBO_DOS,
     S_ROBO_TRES,
     S_ROBO_CUATRO,
-	S_CODIGO_CUATRO,
 
     NUM_SONIDOS // Número total de sonidos
 } l_sonidos;


### PR DESCRIPTION
Se revirtieron los cambios realizados anteriormente luego de testearlos por un tiempo.

Con la actualización se modifica:
- Una de las condiciones para que suenen los avisos de centralita roleados, el dispatch se cambio por [dispatch].
- Se modifico el ejemplo de configuración de TANGO-1 a ADAM-15.
- Ahora los avisos por radio de justicia suenan como avisos importares antes de que se informe del contenido del mismo.